### PR TITLE
fix(tray): prevent UI stalls after primary display switch via non-blo…

### DIFF
--- a/SharedMemoryHelper.h
+++ b/SharedMemoryHelper.h
@@ -13,6 +13,7 @@ public:
     bool WriteSharedMemory(const std::string& name, const std::string& data);
     std::string ReadSharedMemory(const std::string& name);
     void SignalEvent(const std::string& name);
+    bool TryReadSharedMemoryNoWait(const std::string& name, std::string& out);
     bool DeleteSharedMemory(); // メソッドの宣言を追加
     bool DeleteEvent();
 

--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -16,7 +16,7 @@ public:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     void CreateTrayIcon();
     void ShowContextMenu();
-    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays);
+    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string>& displays);
     void SelectDisplay(int displayIndex);
     void MonitorDisplayChanges();
     void RefreshDisplayList();


### PR DESCRIPTION
…cking shared memory read; re-add tray icon on TaskbarCreated

This commit fixes a bug where the tray icon context menu would intermittently fail to appear after a primary display switch.

The fix involves two main changes:
1. A new non-blocking function, `TryReadSharedMemoryNoWait`, is introduced to read from shared memory without stalling the UI thread. The tray menu now uses this function.
2. The application now handles the "TaskbarCreated" and "WM_DISPLAYCHANGE" messages to re-create the tray icon, ensuring it remains responsive if Explorer restarts or the display configuration changes.