### PR TITLE
修正: GET_X_LPARAMに関するC3861コンパイルエラー

### DIFF
--- a/TaskTrayApp.cpp
+++ b/TaskTrayApp.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <functional>
 #include <windows.h>
+#include <windowsx.h>
 #include <shellapi.h> // for Shell_NotifyIconGetRect
 #include <vector>
 #include <string>


### PR DESCRIPTION
TaskTrayApp.cppに不足していた<windowsx.h>をインクルードし、GET_X_LPARAMおよびGET_Y_LPARAMマクロに関するC3861エラーを修正しました。