### PR TITLE
refactor: Make monitor ordering consistent and robust

### DIFF
--- a/RegistryHelper.h
+++ b/RegistryHelper.h
@@ -11,6 +11,7 @@ public:
     static std::pair<std::string, std::string> ReadRegistry();
     static bool WriteDISPInfoToRegistry(const std::string& DispInfo);
     static std::vector<std::string> ReadDISPInfoFromRegistry();
+    static std::vector<std::string> ReadDISPInfoFromRegistryOrdered();
 };
 
 #endif


### PR DESCRIPTION
This commit refactors the display management logic to ensure consistent monitor ordering across shared memory, the registry, and the tray icon UI.

The key changes are:
- Implemented a deterministic sorting order for displays: OS primary monitor first, then by hardware port order (using the display name's numeric suffix as a proxy).
- Updated shared memory to store the full, ordered list of monitor serial numbers (DISP_INFO_0, DISP_INFO_1, ...) in addition to the legacy selected display key (DISP_INFO).
- Modified the registry helper to read display serials in a guaranteed order (SerialNumber0, SerialNumber1, ...).
- Reworked the change detection mechanism to trigger updates when the display order changes, such as when the OS primary monitor is switched.
- Ensured the tray icon tooltip is always present and correctly reflects the current primary monitor, even after changes.

fix: Add missing header declaration for ReadDISPInfoFromRegistryOrdered

Added the function declaration to RegistryHelper.h to resolve build errors.