### PR TITLE
feat(tasktray): deterministic monitor ordering (primary=0, port order…

### DIFF
--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -8,6 +8,7 @@ struct DisplayInfo {
     std::string name;
     std::string serialNumber;
     bool isPrimary = false;
+    int portIndex = -1; // Add portIndex for sorting
 
 };
 

--- a/RegistryHelper.h
+++ b/RegistryHelper.h
@@ -11,6 +11,8 @@ public:
     static std::pair<std::string, std::string> ReadRegistry();
     static bool WriteDISPInfoToRegistry(const std::string& DispInfo);
     static std::vector<std::string> ReadDISPInfoFromRegistry();
+    static bool WriteSelectedDisplaySerial(const std::string& serial);
+    static std::string ReadSelectedDisplaySerial();
 };
 
 #endif

--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -16,7 +16,8 @@ public:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     void CreateTrayIcon();
     void ShowContextMenu();
-    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays);
+    void UpdateDisplayMenu(HMENU hMenu);
+    std::vector<std::string> GetDisplayListFromSharedMemory();
     void SelectDisplay(int displayIndex);
     void MonitorDisplayChanges();
     void RefreshDisplayList();
@@ -29,6 +30,7 @@ private:
     NOTIFYICONDATA nid;
     std::thread monitorThread;
     std::atomic<bool> running = true;
+    std::vector<std::string> cachedDisplaySerials;
 };
 
 #endif // TASKTRAYAPP_H


### PR DESCRIPTION
…) across shared memory, registry, tray

- Implements full monitor enumeration in DisplayManager to capture all displays on a GPU.
- Uses QueryDisplayConfig to establish a stable port-based ordering.
- Ensures the primary monitor is always at index 0.
- Updates shared memory with an ordered list (DISP_INFO_0..N) and preserves the legacy DISP_INFO key.
- Updates the registry with the same ordered list (SerialNumber0..N).
- The tray menu now reads from shared memory to build the display list in the correct order.
- Persists user's display selection to the registry.
- Improves primary display change detection in the monitor thread.