### PR TITLE
- Set NOTIFYICON_VERSION_4 on initial NIM_ADD to prevent first-hover …

### DIFF
--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -32,6 +32,7 @@ private:
     std::thread monitorThread;
     std::atomic<bool> running = true;
     std::vector<std::string> cachedDisplaySerials;
+    UINT taskbarCreatedMsg;
 };
 
 #endif // TASKTRAYAPP_H

--- a/remote_server_tasktray.cpp
+++ b/remote_server_tasktray.cpp
@@ -75,6 +75,22 @@ int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance,
         }
     }
 
+    typedef BOOL (WINAPI *SetDpiCtxFn)(DPI_AWARENESS_CONTEXT);
+    HMODULE hUser32 = GetModuleHandleW(L"user32.dll");
+    if (hUser32) {
+        auto pSetContext = reinterpret_cast<SetDpiCtxFn>(
+            GetProcAddress(hUser32, "SetProcessDpiAwarenessContext"));
+        if (pSetContext) {
+            if (!pSetContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {
+                DebugLog("WinMain: SetProcessDpiAwarenessContext(PER_MONITOR_AWARE_V2) failed.");
+            } else {
+                DebugLog("WinMain: DPI awareness set to PER_MONITOR_AWARE_V2.");
+            }
+        } else {
+            DebugLog("WinMain: SetProcessDpiAwarenessContext not available.");
+        }
+    }
+
     TaskTrayApp app(hInstance);
     if (!app.Initialize()) {
         DebugLog("WinMain: Failed to initialize TaskTrayApp.");


### PR DESCRIPTION
…no-op.

- Recreate tray icon on WM_DISPLAYCHANGE/WM_SETTINGCHANGE and TaskbarCreated.
- Explicitly set PER_MONITOR_AWARE_V2 at startup (dynamic), no layout/comment changes.
- Keep ordering: primary=0 in shared memory & registry; menu from shared memory.
- No goto; preserved logs/timing; static analysis only (cppcheck).