### PR TITLE
Fix: Add missing include to resolve build error

### DIFF
--- a/TaskTrayApp.cpp
+++ b/TaskTrayApp.cpp
@@ -2,6 +2,7 @@
 #include "StringConversion.h"
 #include "GPUManager.h"
 #include "DisplayManager.h"
+#include "Utility.h"
 #include "RegistryHelper.h"
 #include "SharedMemoryHelper.h"
 #include <tchar.h>


### PR DESCRIPTION
Adds `#include "Utility.h"` to `TaskTrayApp.cpp` to make the `utf16_to_utf8` function available, resolving a compiler error.

Original commit message:
Refactor display ordering and persistence logic

Implements a comprehensive update to display management based on the project brief.

Key changes:
- Establishes a single source of truth for display order (primary first, then by OS enumeration) in shared memory.
- Writes an ordered list of monitor serials to shared memory (DISP_INFO_0..N) and a count (DISP_INFO_NUM).
- Mirrors the same ordered list to the registry (SerialNumber0..N).
- Updates the tray menu to build its display list directly from shared memory, ensuring order consistency.
- Persists the user's selected display to the registry under the "Selected" value.
- Centralizes display list writing logic into a single helper function to ensure atomicity between shared memory and registry updates.
- Enables Per-Monitor v2 DPI awareness for proper UI scaling on high-DPI displays.