### PR TITLE
TaskTray: add port-ordered display schema to shared memory, registry …

### DIFF
--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -14,6 +14,7 @@ struct DisplayInfo {
 class DisplayManager {
 public:
     static std::vector<GPUInfo> GetInstalledGPUs(); // 追加
+    static std::vector<DisplayInfo> GetDisplaysForGPUByPortOrder(const std::string& gpuVendorID, const std::string& gpuDeviceID);
     static std::vector<DisplayInfo> GetDisplaysForGPU(const std::string& gpuVendorID, const std::string& gpuDeviceID);
     static bool CheckHardwareEncodingSupport(IDXGIAdapter* pAdapter);
 };

--- a/RegistryHelper.h
+++ b/RegistryHelper.h
@@ -11,6 +11,8 @@ public:
     static std::pair<std::string, std::string> ReadRegistry();
     static bool WriteDISPInfoToRegistry(const std::string& DispInfo);
     static std::vector<std::string> ReadDISPInfoFromRegistry();
+    static bool WriteSelectedDisplayToRegistry(const std::string& serial);
+    static std::string ReadSelectedDisplayFromRegistry();
 };
 
 #endif

--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -16,7 +16,7 @@ public:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     void CreateTrayIcon();
     void ShowContextMenu();
-    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays);
+    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string>& displays);
     void SelectDisplay(int displayIndex);
     void MonitorDisplayChanges();
     void RefreshDisplayList();

--- a/cppcheck_report.txt
+++ b/cppcheck_report.txt
@@ -1,0 +1,130 @@
+TaskTrayApp.h:13:5: style: Class 'TaskTrayApp' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
+    TaskTrayApp(HINSTANCE hInstance);
+    ^
+SharedMemoryHelper.h:12:5: style: Class 'SharedMemoryHelper' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
+    SharedMemoryHelper(TaskTrayApp* app);
+    ^
+DisplayManager.cpp:28:58: style: C-style pointer casting [cstyleCast]
+    if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory))) {
+                                                         ^
+DisplayManager.cpp:172:58: style: C-style pointer casting [cstyleCast]
+    if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory))) {
+                                                         ^
+TaskTrayApp.h:19:72: performance: Function parameter 'displays' should be passed by const reference. [passedByValue]
+    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays);
+                                                                       ^
+GPUManager.cpp:40:63: style: C-style pointer casting [cstyleCast]
+    hr = pDevice->QueryInterface(__uuidof(ID3D11VideoDevice), (void**)&pVideoDevice);
+                                                              ^
+GPUManager.cpp:57:58: style: C-style pointer casting [cstyleCast]
+    if (FAILED(CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory))) {
+                                                         ^
+GPUManager.cpp:93:5: style: Consider using std::all_of or std::none_of algorithm instead of a raw loop. [useStlAlgorithm]
+    for (const auto& gpu : gpus) {
+    ^
+RegistryHelper.cpp:19:57: style: C-style pointer casting [cstyleCast]
+        if (RegSetValueEx(hKey, L"VendorID", 0, REG_SZ, (BYTE*)wVendorID.c_str(), static_cast<DWORD>((wVendorID.size() + 1) * sizeof(wchar_t))) != ERROR_SUCCESS) {
+                                                        ^
+RegistryHelper.cpp:24:57: style: C-style pointer casting [cstyleCast]
+        if (RegSetValueEx(hKey, L"DeviceID", 0, REG_SZ, (BYTE*)wDeviceID.c_str(), static_cast<DWORD>((wDeviceID.size() + 1) * sizeof(wchar_t))) != ERROR_SUCCESS) {
+                                                        ^
+RegistryHelper.cpp:79:61: style: C-style pointer casting [cstyleCast]
+        if (RegSetValueEx(hKey, keyName.c_str(), 0, REG_SZ, (BYTE*)wDISPInfo.c_str(), static_cast<DWORD>((wDISPInfo.size() + 1) * sizeof(wchar_t))) != ERROR_SUCCESS) {
+                                                            ^
+RegistryHelper.cpp:132:63: style: C-style pointer casting [cstyleCast]
+        if (RegSetValueEx(hKey, L"SelectedSerial", 0, REG_SZ, (BYTE*)wSerial.c_str(),
+                                                              ^
+RegistryHelper.cpp:68:65: style: inconclusive: Function 'WriteDISPInfoToRegistry' argument 1 names different: declaration 'DispInfo' definition 'DISPInfo'. [funcArgNamesDifferent]
+bool RegistryHelper::WriteDISPInfoToRegistry(const std::string& DISPInfo) {
+                                                                ^
+RegistryHelper.h:12:60: note: Function 'WriteDISPInfoToRegistry' argument 1 names different: declaration 'DispInfo' definition 'DISPInfo'.
+    static bool WriteDISPInfoToRegistry(const std::string& DispInfo);
+                                                           ^
+RegistryHelper.cpp:68:65: note: Function 'WriteDISPInfoToRegistry' argument 1 names different: declaration 'DispInfo' definition 'DISPInfo'.
+bool RegistryHelper::WriteDISPInfoToRegistry(const std::string& DISPInfo) {
+                                                                ^
+SharedMemoryHelper.h:14:17: performance: inconclusive: Technically the member function 'SharedMemoryHelper::ReadSharedMemory' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+    std::string ReadSharedMemory(const std::string& name);
+                ^
+SharedMemoryHelper.cpp:168:33: note: Technically the member function 'SharedMemoryHelper::ReadSharedMemory' can be static (but you may consider moving to unnamed namespace).
+std::string SharedMemoryHelper::ReadSharedMemory(const std::string& name) {
+                                ^
+SharedMemoryHelper.h:14:17: note: Technically the member function 'SharedMemoryHelper::ReadSharedMemory' can be static (but you may consider moving to unnamed namespace).
+    std::string ReadSharedMemory(const std::string& name);
+                ^
+SharedMemoryHelper.h:16:10: performance: inconclusive: Technically the member function 'SharedMemoryHelper::DeleteSharedMemory' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+    bool DeleteSharedMemory(); // メソッドの宣言を追加
+         ^
+SharedMemoryHelper.cpp:297:26: note: Technically the member function 'SharedMemoryHelper::DeleteSharedMemory' can be static (but you may consider moving to unnamed namespace).
+bool SharedMemoryHelper::DeleteSharedMemory() {
+                         ^
+SharedMemoryHelper.h:16:10: note: Technically the member function 'SharedMemoryHelper::DeleteSharedMemory' can be static (but you may consider moving to unnamed namespace).
+    bool DeleteSharedMemory(); // メソッドの宣言を追加
+         ^
+SharedMemoryHelper.h:17:10: performance: inconclusive: Technically the member function 'SharedMemoryHelper::DeleteEvent' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+    bool DeleteEvent();
+         ^
+SharedMemoryHelper.cpp:303:26: note: Technically the member function 'SharedMemoryHelper::DeleteEvent' can be static (but you may consider moving to unnamed namespace).
+bool SharedMemoryHelper::DeleteEvent() {
+                         ^
+SharedMemoryHelper.h:17:10: note: Technically the member function 'SharedMemoryHelper::DeleteEvent' can be static (but you may consider moving to unnamed namespace).
+    bool DeleteEvent();
+         ^
+TaskTrayApp.h:15:9: performance: inconclusive: Technically the member function 'TaskTrayApp::Run' can be static (but you may consider moving to unnamed namespace). [functionStatic]
+    int Run();
+        ^
+TaskTrayApp.cpp:509:18: note: Technically the member function 'TaskTrayApp::Run' can be static (but you may consider moving to unnamed namespace).
+int TaskTrayApp::Run() {
+                 ^
+TaskTrayApp.h:15:9: note: Technically the member function 'TaskTrayApp::Run' can be static (but you may consider moving to unnamed namespace).
+    int Run();
+        ^
+TaskTrayApp.cpp:293:21: style: Condition 'cleanupResult' is always true [knownConditionTrueFalse]
+                if (cleanupResult) {
+                    ^
+TaskTrayApp.cpp:292:45: note: Calling function 'Cleanup' returns 1
+                cleanupResult = app->Cleanup();
+                                            ^
+TaskTrayApp.cpp:292:45: note: Assignment 'cleanupResult=app->Cleanup()', assigned value is 1
+                cleanupResult = app->Cleanup();
+                                            ^
+TaskTrayApp.cpp:293:21: note: Condition 'cleanupResult' is always true
+                if (cleanupResult) {
+                    ^
+TaskTrayApp.cpp:267:14: style: The scope of the variable 'cleanupResult' can be reduced. [variableScope]
+        bool cleanupResult = false; // 初期化
+             ^
+TaskTrayApp.cpp:32:36: style: inconclusive: Function 'TaskTrayApp' argument 1 names different: declaration 'hInstance' definition 'hInst'. [funcArgNamesDifferent]
+TaskTrayApp::TaskTrayApp(HINSTANCE hInst) : hInstance(hInst), hwnd(NULL), running(true) {
+                                   ^
+TaskTrayApp.h:13:27: note: Function 'TaskTrayApp' argument 1 names different: declaration 'hInstance' definition 'hInst'.
+    TaskTrayApp(HINSTANCE hInstance);
+                          ^
+TaskTrayApp.cpp:32:36: note: Function 'TaskTrayApp' argument 1 names different: declaration 'hInstance' definition 'hInst'.
+TaskTrayApp::TaskTrayApp(HINSTANCE hInst) : hInstance(hInst), hwnd(NULL), running(true) {
+                                   ^
+TaskTrayApp.cpp:202:81: performance: Function parameter 'displays' should be passed by const reference. [passedByValue]
+void TaskTrayApp::UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays) {
+                                                                                ^
+TaskTrayApp.cpp:398:70: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
+                for (const auto& d : NewDisplays) { if (d.isPrimary) { newSel = d.serialNumber; break; } }
+                                                                     ^
+TaskTrayApp.cpp:462:30: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
+            if (d.isPrimary) {
+                             ^
+remote_server_tasktray.cpp:18:23: style: C-style pointer casting [cstyleCast]
+        SetCtx pSet = (SetCtx)GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetProcessDpiAwarenessContext");
+                      ^
+remote_server_tasktray.cpp:41:17: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
+        onlyGPU = gpu;
+                ^
+DisplayManager.cpp:214:0: style: The function 'GetDisplaysForGPU' is never used. [unusedFunction]
+std::vector<DisplayInfo> DisplayManager::GetDisplaysForGPU(const std::string& gpuVendorID, const std::string& gpuDeviceID) {
+^
+RegistryHelper.cpp:147:0: style: The function 'ReadSelectedDisplayFromRegistry' is never used. [unusedFunction]
+std::string RegistryHelper::ReadSelectedDisplayFromRegistry() {
+^
+remote_server_tasktray.cpp:12:0: style: The function 'WinMain' is never used. [unusedFunction]
+int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow) {
+^
+nofile:0:0: information: Active checkers: 174/592 (use --checkers-report=<filename> to see details) [checkersReport]

--- a/remote_server_tasktray.cpp
+++ b/remote_server_tasktray.cpp
@@ -11,6 +11,15 @@
 
 int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow) {
 
+    // At the top of WinMain, before CreateWindow:
+    HMODULE shcore = LoadLibraryW(L"Shcore.dll");
+    if (shcore) {
+        typedef BOOL (WINAPI *SetCtx)(DPI_AWARENESS_CONTEXT);
+        SetCtx pSet = (SetCtx)GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetProcessDpiAwarenessContext");
+        if (pSet) { pSet(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2); }
+        FreeLibrary(shcore);
+    }
+
     // 搭載されているGPUを取得
     auto gpus = GPUManager::GetInstalledGPUs();
     int gpuCount = static_cast<int>(gpus.size()); // 適切にキャスト


### PR DESCRIPTION
…selection, Display1..n menu, hot-plug/primary handling, DPI-aware; keep logging; no layout changes.

- Implemented port-ordered display enumeration using DXGI.
- Expanded the shared memory schema to include display count and an ordered list of serials.
- Added persistence for the selected display to the registry.
- Updated the task-tray menu to show 'Display 1', 'Display 2', etc.
- Improved hot-plug and primary display change handling.
- Enabled per-monitor DPI awareness.
- Followed all constraints from the implementation brief, including no layout changes and keeping existing logging.