### PR TITLE
Fix multiple C++ compilation errors.

### DIFF
--- a/StringConversion.cpp
+++ b/StringConversion.cpp
@@ -8,3 +8,11 @@ std::string ConvertWStringToString(const std::wstring& wstr) {
     WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
     return strTo;
 }
+
+std::wstring ConvertStringToWString(const std::string& str) {
+    if (str.empty()) return std::wstring();
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
+    std::wstring wstrTo(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstrTo[0], size_needed);
+    return wstrTo;
+}

--- a/StringConversion.h
+++ b/StringConversion.h
@@ -4,5 +4,6 @@
 #include <string>
 
 std::string ConvertWStringToString(const std::wstring& wstr);
+std::wstring ConvertStringToWString(const std::string& str);
 
 #endif // STRING_CONVERSION_H

--- a/TaskTrayApp.cpp
+++ b/TaskTrayApp.cpp
@@ -318,7 +318,7 @@ void TaskTrayApp::MonitorDisplayChanges() {
                     wchar_t serialBuf[512];
                     DWORD serialBufSize = sizeof(serialBuf);
                     if (RegQueryValueEx(hKeyRead, valueName, NULL, NULL, (LPBYTE)serialBuf, &serialBufSize) == ERROR_SUCCESS) {
-                        oldDisplaySerials.push_back(utf16_to_utf8(serialBuf));
+                        oldDisplaySerials.push_back(ConvertWStringToString(serialBuf));
                     }
                 }
                 valueNameSize = 256;
@@ -540,7 +540,8 @@ void TaskTrayApp::UpdateTooltip() {
         }
     }
 
-    lstrcpyn(nid.szTip, utf8_to_utf16(tooltipText).c_str(), sizeof(nid.szTip) / sizeof(nid.szTip[0]));
+    std::wstring tooltipW = ConvertStringToWString(tooltipText);
+    lstrcpynW(nid.szTip, tooltipW.c_str(), sizeof(nid.szTip) / sizeof(nid.szTip[0]));
     nid.uFlags |= NIF_TIP;
 
     if (!Shell_NotifyIcon(NIM_MODIFY, &nid)) {

--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -16,7 +16,7 @@ public:
     static LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     void CreateTrayIcon();
     void ShowContextMenu();
-    void UpdateDisplayMenu(HMENU hMenu, const std::vector<std::string> displays);
+    void UpdateDisplayMenu(HMENU hMenu);
     void SelectDisplay(int displayIndex);
     void MonitorDisplayChanges();
     void RefreshDisplayList();


### PR DESCRIPTION
This commit addresses several compilation errors reported by the user:
- Corrected the function signature of `UpdateDisplayMenu` in `TaskTrayApp.h` to match its definition and usage in `TaskTrayApp.cpp`, resolving errors C2660 and C2511.
- Implemented a new `ConvertStringToWString` utility function for UTF-8 to UTF-16 conversions.
- Replaced calls to the non-existent functions `utf16_to_utf8` and `utf8_to_utf16` with the correct string conversion utilities, resolving error C3861.
- Refactored the `UpdateTooltip` function to use a local wstring variable, preventing a dangling pointer and fixing the `lstrcpynW` call (error C2660).