### PR TITLE
fix: correct build errors

### DIFF
--- a/DisplayManager.cpp
+++ b/DisplayManager.cpp
@@ -114,7 +114,7 @@ static bool EnumerateOutputsPortOrder(IDXGIAdapter* pAdapter, std::vector<Displa
 
         MONITORINFOEXW mi;
         mi.cbSize = sizeof(mi);
-        if (!GetMonitorInfoW(desc.hMonitor, &mi)) {
+        if (!GetMonitorInfoW(desc.Monitor, &mi)) {
             DebugLog("EnumerateOutputsPortOrder: Failed to get monitor info.");
             pOutput->Release();
             continue;

--- a/TaskTrayApp.cpp
+++ b/TaskTrayApp.cpp
@@ -1,5 +1,6 @@
 ﻿#include "TaskTrayApp.h"
 #include "StringConversion.h"
+#include "Utility.h"
 #include "GPUManager.h"
 #include "DisplayManager.h"
 #include "RegistryHelper.h"


### PR DESCRIPTION
This commit fixes two build errors that were present in the previous commit for deterministic monitor handling.

- In DisplayManager.cpp, corrected the access to the monitor handle in the DXGI_OUTPUT_DESC struct from `hMonitor` to `Monitor`.
- In TaskTrayApp.cpp, added the missing include for "Utility.h" which provides the declaration for the `utf16_to_utf8` function used in logging.