### PR TITLE
feat: Select OS primary monitor on startup

### DIFF
--- a/DisplayManager.h
+++ b/DisplayManager.h
@@ -14,6 +14,7 @@ struct DisplayInfo {
 class DisplayManager {
 public:
     static std::vector<GPUInfo> GetInstalledGPUs(); // 追加
+    static std::string GetSystemPrimaryDisplaySerial();
     static std::vector<DisplayInfo> GetDisplaysForGPU(const std::string& gpuVendorID, const std::string& gpuDeviceID);
     static bool CheckHardwareEncodingSupport(IDXGIAdapter* pAdapter);
 };


### PR DESCRIPTION
Implements a new system-wide check to identify the OS's primary monitor. The application now correctly selects the primary monitor on startup, even if it is not on the same GPU that the application is configured to manage.

If the OS primary monitor is not on the managed GPU, the application falls back to selecting the first available display on the managed GPU.