### PR TITLE
fix(build): add OverlayManager source files to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     SharedMemoryHelper.cpp
     StringConversion.cpp
     Utility.cpp
+    OverlayManager.cpp
 )
 
 # ヘッダーファイル
@@ -46,6 +47,7 @@ set(HEADERS
     framework.h
     targetver.h
     Resource.h
+    OverlayManager.h
 )
 
 # リソースファイル


### PR DESCRIPTION
Resolves LNK2019 unresolved external symbol errors by adding OverlayManager.cpp to the list of source files and OverlayManager.h to the list of headers in the CMakeLists.txt file.

This ensures the new module is correctly compiled and linked.

chore(static-analysis): update cppcheck report