### PR TITLE
feat: ログローテーションと保存場所の変更を実装

### DIFF
--- a/DebugLog.cpp
+++ b/DebugLog.cpp
@@ -5,12 +5,45 @@
 #include <filesystem>
 #include <atomic>
 #include <mutex>
+#include <vector>
+#include <algorithm>
 
 // ログの呼び出し回数をカウントする静的変数
 static std::atomic<int> logCounter(0);
 
 // ログ書き込みの排他処理用のミューテックス
 static std::mutex logMutex;
+
+void InitializeLogger() {
+    char exePath[MAX_PATH];
+    GetModuleFileNameA(NULL, exePath, MAX_PATH);
+    std::filesystem::path exeDir = std::filesystem::path(exePath).remove_filename();
+    std::filesystem::path logFilePath = exeDir / "debuglog_tasktray.log";
+    std::string baseLogName = logFilePath.stem().string();
+    std::string extension = ".log";
+    std::string backup_extension = ".back";
+
+    // 5番目のバックアップファイルを削除
+    std::filesystem::path old_log_path = exeDir / (baseLogName + extension + backup_extension + ".5");
+    if (std::filesystem::exists(old_log_path)) {
+        std::filesystem::remove(old_log_path);
+    }
+
+    // 4番から1番のファイルをリネーム
+    for (int i = 4; i >= 1; --i) {
+        std::filesystem::path current_path = exeDir / (baseLogName + extension + backup_extension + "." + std::to_string(i));
+        if (std::filesystem::exists(current_path)) {
+            std::filesystem::path next_path = exeDir / (baseLogName + extension + backup_extension + "." + std::to_string(i + 1));
+            std::filesystem::rename(current_path, next_path);
+        }
+    }
+
+    // 現在のログファイルをリネーム
+    if (std::filesystem::exists(logFilePath)) {
+        std::filesystem::path new_log_path = exeDir / (baseLogName + extension + backup_extension + ".1");
+        std::filesystem::rename(logFilePath, new_log_path);
+    }
+}
 
 void DebugLog(const std::string& message) {
     // ログの呼び出し回数をインクリメント
@@ -25,11 +58,8 @@ void DebugLog(const std::string& message) {
     // 実行ファイルのパスを取得
     char exePath[MAX_PATH];
     GetModuleFileNameA(NULL, exePath, MAX_PATH);
-    std::filesystem::path buildDir = std::filesystem::path(exePath).remove_filename();
-    std::filesystem::path logFilePath = buildDir / "Debug" / "debuglog_tasktray.log";
-    
-    // Debugディレクトリが存在しない場合は作成
-    std::filesystem::create_directories(buildDir / "Debug");
+    std::filesystem::path exeDir = std::filesystem::path(exePath).remove_filename();
+    std::filesystem::path logFilePath = exeDir / "debuglog_tasktray.log";
 
     // ログファイルにメッセージを出力（排他処理）
     std::lock_guard<std::mutex> lock(logMutex);

--- a/DebugLog.h
+++ b/DebugLog.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
 
+void InitializeLogger();
 void DebugLog(const std::string& message);
 

--- a/remote_server_tasktray.cpp
+++ b/remote_server_tasktray.cpp
@@ -64,6 +64,7 @@ static bool GetPrimaryAdapterVendorDevice(std::string& outVendorID, std::string&
 }
 
 int APIENTRY WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow) {
+    InitializeLogger();
     // Set Per-Monitor DPI Awareness to handle different DPIs across monitors.
     // This is crucial for ensuring the tray menu and tooltips are positioned correctly.
     HMODULE user32 = LoadLibrary(L"user32.dll");


### PR DESCRIPTION
ログファイルの管理機能を改善し、以下の変更を行いました。

- 実行ファイルと同じディレクトリにログを保存するように変更
- アプリ起動時にログファイルを.back.*としてリネームするローテーション機能を追加
- バックアップファイルが5つを超えた場合、最も古いファイルを削除する機能を追加