### PR TITLE
Add capture mode menu and update shared memory flags

### DIFF
--- a/TaskTrayApp.h
+++ b/TaskTrayApp.h
@@ -17,7 +17,9 @@ public:
     void CreateTrayIcon();
     void ShowContextMenu();
     void UpdateDisplayMenu(HMENU hMenu);
+    void UpdateCaptureModeMenu(HMENU hMenu);
     void SelectDisplay(int displayIndex);
+    void SetCaptureMode(int mode);
     void MonitorDisplayChanges();
     void RefreshDisplayList();
     bool Cleanup();
@@ -25,6 +27,7 @@ public:
 
 private:
     void UpdateTrayTooltip(const std::wstring& text);
+    void PulseRebootFlag();
 
     HINSTANCE hInstance;
     HWND hwnd;


### PR DESCRIPTION
## Summary
- rename the tray menu entry to “Display Selection” and add a new CaptureMode submenu with Normal and Game options
- initialize the Capture_Mode shared memory value, default to Normal Mode, and toggle menu check marks from shared memory
- pulse the REBOOT shared memory flag when capture mode changes and update existing code to use the new REBOOT name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac787e3388321be5fbebc7d119ad5